### PR TITLE
Replace date validation of recurring transactions ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ php artisan serve
 php artisan queue:work
 ```
 
+In addition to this you will have to create a cronjob to trigger budgets scheduling.  
+(Without this, recurring transactions and weekly reports won't work)
+
+```
+* * * * * cd /path/to/budget/ && php artisan schedule:run >> 2>&1 
+``` 
+
+It's best to make sure this command is run with the user that runs budget (eg. www-data) 
+
 ## Contact
 
 * [Discord](https://discord.gg/QFQdvy3)

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -29,7 +29,7 @@ class Kernel extends ConsoleKernel
         // $schedule->command('inspire')
         //          ->hourly();
 
-        $schedule->job(new ProcessRecurrings)->everyMinute();
+        $schedule->job(new ProcessRecurrings)->daily();
 
         $schedule->job(new SendWeeklyReports)->weekly()->fridays()->at('21:00');
     }

--- a/app/Jobs/ProcessRecurrings.php
+++ b/app/Jobs/ProcessRecurrings.php
@@ -18,9 +18,17 @@ class ProcessRecurrings implements ShouldQueue {
     }
 
     public function handle() {
+        $day = (int) date('j');
+
         $recurrings = Recurring
             ::where('type', 'monthly')
-            ->where('day', date('j'))
+            ->when((int) date('t')  == $day, 
+            function ($query) use ($day) {
+                return $query->where('day', '>=', $day);
+            }, 
+            function ($query) use ($day) {
+                return $query->where('day', $day);
+            })
             ->where('starts_on', '<=', date('Y-m-d'))
             ->where(function ($query) {
                 $query


### PR DESCRIPTION
... to make transactions possible at every day of month

As per the issue I submitted, recurring transactions could not be entered because of date incompatibilities. This fixes #16 

