### PR TITLE
Remove action from empty-state

### DIFF
--- a/resources/views/partials/empty_state.blade.php
+++ b/resources/views/partials/empty_state.blade.php
@@ -1,4 +1,3 @@
 <div class="box__section text-center">
-    <div class="mb-1">{{ __('general.empty_state', ['resource' => strtolower(__('models.' . $payload))]) }}</div>
-    <a href="/{{ $payload }}/create" style="font-size: 14px;">{{ __('actions.create') }}</a>
+    <div class="mb-1">{{ __('messages.empty_state', ['resource' => strtolower(__('models.' . $payload))]) }}</div>
 </div>


### PR DESCRIPTION
Remove action from empty-state because all pages have a button for the action