### PR TITLE
148 Docker image (Web + Cron + PHP)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+/node_modules
+/public/hot
+/public/storage
+/storage/*.key
+/vendor
+/.idea
+/.vagrant
+Homestead.json
+Homestead.yaml
+npm-debug.log
+yarn-error.log
+.env
+.DS_Store
+/public/css
+/public/mix-manifest.json
+/public/js
+version.txt

--- a/README.md
+++ b/README.md
@@ -53,9 +53,17 @@ php artisan budget:update
 
 ## Docker
 
-You can run Budget using Docker. Spinning it up (`docker-compose up`) will create 3 containers–for MySQL, PHP and NGINX.
+You can run Budget using Docker Compose. Docker Compose starts 2 containers - one for the database and the other for the application itself.
 
-*Disclaimer–currently the Docker setup is missing cronjobs and the queue worker.*
+1. Clone the repository
+2. Copy the `.env.example` to `.env`, make sure to review/replace any other value as you wish
+3. Generate an `API_KEY` (`docker-compose run --entrypoint php php artisan key:generate --no-ansi --show`) and put that into your `.env`
+   The `APP_KEY` should be rotated carefully as session cookies are encrypted with this value
+3. Make sure you have the most up-to-date images (`docker-compose pull`)
+4. Run the stack (`docker-compose up`)
+5. Budget should be available at [http://localhost:8080](http://localhost:8080) shortly
+
+*Disclaimer–currently the Docker setup is missing the queue worker.*
 
 ## Contact
 

--- a/cron.conf
+++ b/cron.conf
@@ -1,0 +1,1 @@
+* * * * * www-data cd /usr/share/nginx/budget && /usr/local/bin/php artisan schedule:run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3'
 
 volumes:
   database2: {}
-  built_app: {}
 
 services:
   # Named "database2" because "database" conflicts with directory inside project
@@ -19,20 +18,12 @@ services:
 
   php:
     build: ./
+    ports:
+      - 8080:80
+    env_file:
+    - .env
     environment:
       DB_HOST: database2
       DB_DATABASE: budget
       DB_USERNAME: budget
       DB_PASSWORD: test
-    volumes:
-      - built_app:/usr/share/nginx/budget
-
-  nginx:
-    image: nginx:latest
-    depends_on:
-      - php # To ensure that "built_app" volume gets filled by "php" service
-    volumes:
-      - built_app:/usr/share/nginx/budget
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf
-    ports:
-      - 8080:80

--- a/docker_boot.sh
+++ b/docker_boot.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
-./wait-for-it.sh database2:3306 -- php artisan migrate
+set -e
 
-php-fpm
+DB_HOST="${DB_HOST:?environment variable is missing}"
+DB_PORT="${DB_PORT:-3306}"
+
+./wait-for-it.sh "${DB_HOST}:${DB_PORT}" -- php artisan migrate
+
+# php artisan optimize
+
+php artisan storage:link
+
+exec $@

--- a/docker_boot.sh
+++ b/docker_boot.sh
@@ -5,7 +5,7 @@ set -e
 DB_HOST="${DB_HOST:?environment variable is missing}"
 DB_PORT="${DB_PORT:-3306}"
 
-./wait-for-it.sh "${DB_HOST}:${DB_PORT}" -- php artisan migrate
+./wait-for-it.sh "${DB_HOST}:${DB_PORT}" -- php artisan migrate --force
 
 # php artisan optimize
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,7 +19,7 @@ server {
         fastcgi_param PATH_INFO       $fastcgi_path_info;
         fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
 
-        fastcgi_pass   php:9000;
+        fastcgi_pass   127.0.0.1:9000;
         fastcgi_index  index.php;
     }
 }

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,29 @@
+[supervisord]
+user=root
+
+[program:cron]
+command=cron -f
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=false
+startretries=0
+
+[program:php-fpm]
+command=php-fpm -F
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=false
+startretries=0
+
+[program:nginx]
+command=nginx -g 'daemon off;'
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=false
+startretries=0


### PR DESCRIPTION
This PR will extend our application docker image:
- NGINX, so we can get rid of the nginx service in docker-compose.yml
- crond, now laravels scheduler should work ootb
- php-fpm (as before)
- supervisord as our init

There are a few gotchas:
- Because we now include a .dockerignore, a few host files aren't included in the image anymore. Most prominent is the .env file, which was used by the docker-compose setup to set the APP_ENV, APP_KEY etc.
It's probably fine to just address it in the README accordingly

- The image is now build in multiple stages and I pulled all the npm stuff into their own stage. Upside is that we do not need the npm tools in our final image. But if someone or something was relying on those tools they are out of luck now.