### PR TITLE
Fix vite npm dependencies and missing git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 # Install NGINX and other packages
 RUN apt-get update && \
     apt-get install -y \
+      git \
       nginx \
       cron \
       supervisor
@@ -26,7 +27,7 @@ RUN install-php-extensions pdo_mysql zip calendar gd
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Install Node.js and Yarn
-RUN curl -sL https://deb.nodesource.com/setup_15.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs && \
     npm install -g yarn
 


### PR DESCRIPTION
Fix for [New install throws 500 Errorcode #386](https://github.com/range-of-motion/budget/issues/386) issue. 

Before patch `npm` failed to install dependencies due this error:
```
error @vitejs/plugin-vue2@2.2.0: The engine "node" is incompatible with this module. Expected version "^14.18.0 || >= 16.0.0". Got "15.14.0"
error Found incompatible module.
```
So `vite` manifest file was not created, that caused this error:
```
production.ERROR: Vite manifest not found at: /var/www/public/build/manifest.json (View: /var/www/resources/views/layout.blade.php) (View: /var/www/resources/views/layout.blade.php) {"exception":"[object] (Illuminate\\View\\ViewException(code: 0): Vite manifest not found at: /var/www/public/build/manifest.json (View: /var/www/resources/views/layout.blade.php) (View: /var/www/resources/views/layout.blade.php) at /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Vite.php:684)
[stacktrace]
```

Also added `git`, because it was missing in the docker image:
```
> Illuminate\Foundation\ComposerScripts::postInstall
> git describe --always --tags > version.txt
sh: 1: git: not found
Script git describe --always --tags > version.txt handling the post-install-cmd event returned with error code 127
```