### PR TITLE
fix Missing required parameter for [Route: reports.show]

### DIFF
--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -8,13 +8,13 @@
         <div class="row row--gutter row--responsive mt-3">
             <div class="row__column">
                 <div class="card">
-                    <a href="{{ route('reports.show', ['slug' => 'weekly-report']) }}">{{ __('reports.weekly_balance.title') }}</a>
+                    <a href="{{ route('reports.show', ['report' => 'weekly-report']) }}">{{ __('reports.weekly_balance.title') }}</a>
                     <p class="mt-1">{!! __('reports.weekly_balance.description') !!}</p>
                 </div>
             </div>
             <div class="row__column">
                 <div class="card">
-                    <a href="{{ route('reports.show', ['slug' => 'most-expensive-tags']) }}">{{ __('reports.most_expensive_tags.title') }}</a>
+                    <a href="{{ route('reports.show', ['report' => 'most-expensive-tags']) }}">{{ __('reports.most_expensive_tags.title') }}</a>
                     <p class="mt-1">{!! __('reports.most_expensive_tags.description') !!}</p>
                 </div>
             </div>

--- a/resources/views/reports/weekly_report.blade.php
+++ b/resources/views/reports/weekly_report.blade.php
@@ -4,8 +4,8 @@
     <div class="wrapper my-3">
         <h2>Weekly Report {{ $year }}</h2>
         <div class="row mt-1">
-            <a class="mr-1" href="{{ route('reports.show', ['slug' => 'weekly-report', 'year' => $year - 1]) }}">Previous</a>
-            <a href="{{ route('reports.show', ['slug' => 'weekly-report', 'year' => $year + 1]) }}">Next</a>
+            <a class="mr-1" href="{{ route('reports.show', ['report' => 'weekly-report', 'year' => $year - 1]) }}">Previous</a>
+            <a href="{{ route('reports.show', ['report' => 'weekly-report', 'year' => $year + 1]) }}">Next</a>
         </div>
         <div class="box mt-3">
             <div class="box__section">


### PR DESCRIPTION
I have fixed the issue of Missing the required parameter for [Route: reports.show].

![Dashboard-Budget](https://github.com/range-of-motion/budget/assets/28540285/1485cf50-a896-4574-9592-e20dd3b8303c)

![Missing-required-parameter-for-Route-reports-show-URI-reports-report-Missing-parameter-report-View-Users-boni-Sites-php-projects-budget-resources-views-reports-index-blade-php-500-Internal-Server-Error- (1)](https://github.com/range-of-motion/budget/assets/28540285/e2cc5a48-7a6a-400b-818e-7b66f3aee588)


Steps to check  Dashboard -> reports

Kidly verify and accept.