### PR TITLE
Update budget:install to be compatible with vite

### DIFF
--- a/app/Console/Commands/BudgetInstall.php
+++ b/app/Console/Commands/BudgetInstall.php
@@ -35,7 +35,7 @@ class BudgetInstall extends Command
         $this->executeCommand(['npm', 'install']);
 
         $this->info('Compiling front-end assets');
-        $this->executeCommand(['npm', 'run', 'production']);
+        $this->executeCommand(['npm', 'run', 'build']);
 
         $this->executeCommand(['cp', '.env.example', '.env']);
         $this->executeCommand(['php', 'artisan', 'key:generate']);


### PR DESCRIPTION
I updated the php artisan budget:install to execute `npm run build` instead of the initial `npm run production`
This is due to the update from the initial mix to vite